### PR TITLE
Add type for automatic installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+    "type": "pre-macro",
     "name": "md/for-comprehension-preprocessor",
     "license": "MIT",
     "require": {


### PR DESCRIPTION
Without this type, consumers need to call `\Pre\Plugin\addMacroPath(...)`.